### PR TITLE
local_cache fixture should not ignore custom settings

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -10,12 +10,39 @@ pytest-tipsi-django
 .. contents:: **Table of Contents**
     :backlinks: none
 
+
 Installation
 ------------
 
 .. code-block:: bash
 
     $ pip install pytest-tipsi-django
+    
+Features 
+------------
+
+* Default django test settings
+
+  - if you run pytest after install pytest-tipsi-django, 
+    Configuration already has django settings.CACHE['default']
+   
+  - of course if you has Custom django settings, this settings to below are ignored.
+
+.. code-block:: python
+    
+    DEFAULT_FILE_STORAGE = 'django.core.files.storage.FileSystemStorage'
+    BROKER_BACKEND = 'memory'
+    CACHES = {
+        'default': {
+            'BACKEND': 'django.core.cache.backends.locmem.LocMemCache',
+            'TIMEOUT': 60 * 15
+        }
+    }
+   
+  
+  
+  
+  
 
 License
 -------

--- a/pytest_tipsi_django/plugin.py
+++ b/pytest_tipsi_django/plugin.py
@@ -73,7 +73,7 @@ def auto_transaction(request):
             yield
 
 
-@pytest.fixture(scope='session', autouse=True)  # noqa
+@pytest.fixture(scope='session', autouse=False)  # noqa
 def local_cache(session_settings, django_db_setup):
     session_settings.DEFAULT_FILE_STORAGE = 'django.core.files.storage.FileSystemStorage'
     session_settings.BROKER_BACKEND = 'memory'

--- a/pytest_tipsi_django/plugin.py
+++ b/pytest_tipsi_django/plugin.py
@@ -76,11 +76,9 @@ def auto_transaction(request):
 
 @pytest.fixture(scope='session', autouse=True)  # noqa
 def local_cache(session_settings, django_db_setup):
-    if not getattr(session_settings, 'DEFAULT_FILE_STORAGE', None):
-        session_settings.DEFAULT_FILE_STORAGE = 'django.core.files.storage.FileSystemStorage'
-    if not getattr(session_settings, 'BROKER_BACKEND', None):
-        session_settings.BROKER_BACKEND = 'memory'
-    if not getattr(session_settings, 'CACHES', None):
+    session_settings.DEFAULT_FILE_STORAGE = 'django.core.files.storage.FileSystemStorage'
+    session_settings.BROKER_BACKEND = 'memory'
+    if not hasattr(session_settings, 'CACHES', None):
         session_settings.CACHES['default'] = {
             'BACKEND': 'django.core.cache.backends.locmem.LocMemCache',
             'TIMEOUT': 60 * 15

--- a/pytest_tipsi_django/plugin.py
+++ b/pytest_tipsi_django/plugin.py
@@ -81,11 +81,9 @@ def local_cache(session_settings, django_db_setup):
     if not getattr(session_settings, 'BROKER_BACKEND', None):
         session_settings.BROKER_BACKEND = 'memory'
     if not getattr(session_settings, 'CACHES', None):
-        session_settings.CACHES = {
-            'default': {
-                'BACKEND': 'django.core.cache.backends.locmem.LocMemCache',
-                'TIMEOUT': 60 * 15
-            }
+        session_settings.CACHES['default'] = {
+            'BACKEND': 'django.core.cache.backends.locmem.LocMemCache',
+            'TIMEOUT': 60 * 15
         }
     yield session_settings
 

--- a/pytest_tipsi_django/plugin.py
+++ b/pytest_tipsi_django/plugin.py
@@ -5,7 +5,7 @@ from pytest_tipsi_django.client_fixtures import UserWrapper
 from pytest_tipsi_django.django_fixtures import (  # noqa
     session_settings, module_settings, function_settings,
     module_transaction, function_fixture, module_fixture,
-    django_assert_num_queries
+    django_assert_num_queries,
 )
 
 
@@ -31,6 +31,7 @@ def pytest_addoption(parser):
                     help='Write http requests for documentation')
     group.addoption('--verbose_request', action='store_true', default=False,
                     help='Print all requests to stdout')
+
 
 def pytest_configure(config):
     options = ['write_docs', 'verbose_request']
@@ -75,11 +76,11 @@ def auto_transaction(request):
 
 @pytest.fixture(scope='session', autouse=True)  # noqa
 def local_cache(session_settings, django_db_setup):
-    if not session_settings.get('DEFAULT_FILE_STORAGE'):
+    if not getattr(session_settings, 'DEFAULT_FILE_STORAGE', None):
         session_settings.DEFAULT_FILE_STORAGE = 'django.core.files.storage.FileSystemStorage'
-    if not session_settings.get('BROKER_BACKEND'):
+    if not getattr(session_settings, 'BROKER_BACKEND', None):
         session_settings.BROKER_BACKEND = 'memory'
-    if not session_settings.get('CACHES'):
+    if not getattr(session_settings, 'CACHES', None):
         session_settings.CACHES = {
             'default': {
                 'BACKEND': 'django.core.cache.backends.locmem.LocMemCache',

--- a/pytest_tipsi_django/plugin.py
+++ b/pytest_tipsi_django/plugin.py
@@ -78,7 +78,7 @@ def auto_transaction(request):
 def local_cache(session_settings, django_db_setup):
     session_settings.DEFAULT_FILE_STORAGE = 'django.core.files.storage.FileSystemStorage'
     session_settings.BROKER_BACKEND = 'memory'
-    if not hasattr(session_settings, 'CACHES', None):
+    if not hasattr(session_settings, 'CACHES'):
         session_settings.CACHES['default'] = {
             'BACKEND': 'django.core.cache.backends.locmem.LocMemCache',
             'TIMEOUT': 60 * 15

--- a/pytest_tipsi_django/plugin.py
+++ b/pytest_tipsi_django/plugin.py
@@ -73,16 +73,19 @@ def auto_transaction(request):
             yield
 
 
-@pytest.fixture(scope='session', autouse=False)  # noqa
+@pytest.fixture(scope='session', autouse=True)  # noqa
 def local_cache(session_settings, django_db_setup):
-    session_settings.DEFAULT_FILE_STORAGE = 'django.core.files.storage.FileSystemStorage'
-    session_settings.BROKER_BACKEND = 'memory'
-    session_settings.CACHES = {
-        'default': {
-            'BACKEND': 'django.core.cache.backends.locmem.LocMemCache',
-            'TIMEOUT': 60 * 15
+    if not session_settings.get('DEFAULT_FILE_STORAGE'):
+        session_settings.DEFAULT_FILE_STORAGE = 'django.core.files.storage.FileSystemStorage'
+    if not session_settings.get('BROKER_BACKEND'):
+        session_settings.BROKER_BACKEND = 'memory'
+    if not session_settings.get('CACHES'):
+        session_settings.CACHES = {
+            'default': {
+                'BACKEND': 'django.core.cache.backends.locmem.LocMemCache',
+                'TIMEOUT': 60 * 15
+            }
         }
-    }
     yield session_settings
 
 

--- a/test_django_plugin/app/tests/test_settings.py
+++ b/test_django_plugin/app/tests/test_settings.py
@@ -1,5 +1,8 @@
+import pytest
+
 
 class TestSettings:
+    @pytest.mark.usefixtures('local_cache')
     def test_01(self, function_settings, session_settings):
         function_settings.CUSTOM_SETTINGS = 5
         from django.conf import settings as dj_settings
@@ -8,4 +11,5 @@ class TestSettings:
 
     def test_02(self):
         from django.conf import settings
-        assert settings.BROKER_BACKEND == 'memory'
+        with pytest.raises(AttributeError):
+            assert settings.BROKER_BACKEND == 'memory'

--- a/test_django_plugin/app/tests/test_settings.py
+++ b/test_django_plugin/app/tests/test_settings.py
@@ -1,3 +1,4 @@
+
 class TestSettings:
     def test_01(self, function_settings, session_settings):
         function_settings.CUSTOM_SETTINGS = 5

--- a/test_django_plugin/app/tests/test_settings.py
+++ b/test_django_plugin/app/tests/test_settings.py
@@ -1,8 +1,4 @@
-import pytest
-
-
 class TestSettings:
-
     def test_01(self, function_settings, session_settings):
         function_settings.CUSTOM_SETTINGS = 5
         from django.conf import settings as dj_settings

--- a/test_django_plugin/app/tests/test_settings.py
+++ b/test_django_plugin/app/tests/test_settings.py
@@ -2,7 +2,7 @@ import pytest
 
 
 class TestSettings:
-    @pytest.mark.usefixtures('local_cache')
+
     def test_01(self, function_settings, session_settings):
         function_settings.CUSTOM_SETTINGS = 5
         from django.conf import settings as dj_settings
@@ -11,5 +11,4 @@ class TestSettings:
 
     def test_02(self):
         from django.conf import settings
-        with pytest.raises(AttributeError):
-            assert settings.BROKER_BACKEND == 'memory'
+        assert settings.BROKER_BACKEND == 'memory'


### PR DESCRIPTION
``` local_cache():```

 this fixture  ignore Project's CacheSettings in  setttings.test.py 

#### for example

#### i set my pytest.ini 
~~~
[pytest]
DJANGO_SETTINGS_MODULE = config.settings.test
~~~ 

AND 

settings.test.py has Django Cache Setting 


~~~


CACHES = {
    'default': {
        'BACKEND': 'django.core.cache.backends.dummy.DummyCache',
    },
    'query': {
        'BACKEND': 'django.core.cache.backends.locmem.LocMemCache',
    },
   'session': {
        'BACKEND': 'django.core.cache.backends.locmem.RedisCacheBlaBla',
   }
}
~~~

### But
####  This Fixture override settings.test.py   CACHES 

~~~Python

@pytest.fixture(scope='session', autouse=True)  # noqa
def local_cache(session_settings, django_db_setup):
    ....
~~~




### it should be modifed