### PR TITLE
Resolve Issue SavepointDoesNotExist with module fixture

### DIFF
--- a/pytest_tipsi_django/django_fixtures.py
+++ b/pytest_tipsi_django/django_fixtures.py
@@ -97,7 +97,7 @@ def function_fixture(request, module_transaction):
         yield
 
 
-@pytest.fixture(scope='module')
+@pytest.fixture(scope='module', autouse=True)
 def module_fixture(request, module_transaction):
     with module_transaction(request.fixturename):
         yield

--- a/test_django_plugin/app/tests/test_with_bug_reproduction.py
+++ b/test_django_plugin/app/tests/test_with_bug_reproduction.py
@@ -5,7 +5,6 @@ from django.contrib.auth.models import User
 from django.test.utils import CaptureQueriesContext
 
 
-
 @pytest.fixture(autouse=True)
 def this_is_module_fixture(module_fixture):
     # create what you want in this module
@@ -49,10 +48,10 @@ def test_check_raise_savepiont_does_not_exist3():
 )
 @pytest.mark.django_db
 def test_check_raise_savepiont_does_not_exist4(parametrize_idx_aaa):
-    User.objects.create(username=f'username_{parametrize_idx_aaa}')
+    User.objects.create(username='username_{}'.value(parametrize_idx_aaa))
 
     # assert 'this user available in module level' in User.objects.all().values_list('username', flat=True)
-    assert f'username_{parametrize_idx_aaa}' in User.objects.all().values_list('username', flat=True)
+    assert 'username_{}'.format(parametrize_idx_aaa) in User.objects.all().values_list('username', flat=True)
     assert User.objects.count() == 2
 
 
@@ -63,7 +62,7 @@ def test_check_raise_savepiont_does_not_exist4(parametrize_idx_aaa):
 )
 @pytest.mark.django_db
 def test_check_raise_savepiont_does_not_exist401(request, parametrize_idx_aaa, expected_value):
-    print(f'\n\n\n--check fixtures---{request.fixturenames}----------\n\n\n')
+    print('\n\n\n--check fixtures---{}----------\n\n\n'.format(request.fixturenames))
 
     User.objects.create(username=f'username_{parametrize_idx_aaa}')
 
@@ -78,7 +77,7 @@ def test_check_raise_savepiont_does_not_exist401(request, parametrize_idx_aaa, e
 )
 @pytest.mark.django_db
 def test_check_raise_savepiont_does_not_exist402(parametrize_idx_aaa, expected_value):
-    User.objects.create(username=f'username_{parametrize_idx_aaa}')
+    User.objects.create(username='username_{}'.format(parametrize_idx_aaa))
 
     assert 'this user available in module level' in User.objects.all().values_list('username', flat=True)
     assert f'username_{parametrize_idx_aaa}' in User.objects.all().values_list('username', flat=True)
@@ -89,7 +88,7 @@ def test_check_raise_savepiont_does_not_exist402(parametrize_idx_aaa, expected_v
 def test_check_raise_savepiont_does_not_exist5():
     from django.db import connection
     with CaptureQueriesContext(connection) as expected_num_queries:
-        User.objects.create(username=f'username_123')
+        User.objects.create(username='username_123')
 
     # with CaptureQueriesContext(connection) as expected_num_queries2:
     #     APIClient().get(path='www.naver.com')

--- a/test_django_plugin/app/tests/test_with_bug_reproduction.py
+++ b/test_django_plugin/app/tests/test_with_bug_reproduction.py
@@ -1,0 +1,97 @@
+from datetime import datetime
+
+import pytest
+from django.contrib.auth.models import User
+from django.test.utils import CaptureQueriesContext
+
+
+@pytest.fixture(autouse=True)
+def this_is_module_fixture(module_fixture):
+    # create what you want in this module
+    return User.objects.create(username='this user available in module level')
+
+
+@pytest.fixture(scope='function', autouse=False)
+def this_is_function_fixture():
+    return User.objects.create(username='this user available in function level')
+
+
+@pytest.mark.usefixtures('this_is_module_fixture')
+@pytest.mark.django_db
+def test_check_raise_savepiont_does_not_exist(request):
+    assert User.objects.all().first().username == 'this user available in module level'
+    assert User.objects.count() == 1
+
+
+@pytest.mark.usefixtures('this_is_module_fixture')
+@pytest.mark.django_db
+def test_check_raise_savepiont_does_not_exist2():
+    User.objects.create(username='this user available only in this testcase')
+
+    assert 'this user available in module level' in User.objects.all().values_list('username', flat=True)
+    assert 'this user available only in this testcase' in User.objects.all().values_list('username', flat=True)
+    assert User.objects.count() == 2
+
+
+@pytest.mark.usefixtures('this_is_module_fixture')
+@pytest.mark.usefixtures('this_is_function_fixture')
+@pytest.mark.django_db
+def test_check_raise_savepiont_does_not_exist3():
+    assert 'this user available in module level' in User.objects.all().values_list('username', flat=True)
+    assert 'this user available in function level' in User.objects.all().values_list('username', flat=True)
+    assert User.objects.count() == 2
+
+
+@pytest.mark.parametrize(
+    argnames='parametrize_idx_aaa',
+    argvalues=(1, 2, 3, 4,)
+)
+@pytest.mark.django_db
+def test_check_raise_savepiont_does_not_exist4(parametrize_idx_aaa):
+    User.objects.create(username=f'username_{parametrize_idx_aaa}')
+
+    # assert 'this user available in module level' in User.objects.all().values_list('username', flat=True)
+    assert f'username_{parametrize_idx_aaa}' in User.objects.all().values_list('username', flat=True)
+    assert User.objects.count() == 2
+
+
+@pytest.mark.usefixtures('this_is_module_fixture')
+@pytest.mark.parametrize(
+    argnames='parametrize_idx_aaa,expected_value',
+    argvalues=((1, 1), (2, 1), (3, 1), (4, datetime(2019, 10, 11)),)
+)
+@pytest.mark.django_db
+def test_check_raise_savepiont_does_not_exist401(request, http_client, parametrize_idx_aaa, expected_value):
+    print(f'\n\n\n--여기여기---{request.fixturenames}----------\n\n\n')
+
+    User.objects.create(username=f'username_{parametrize_idx_aaa}')
+
+    assert 'this user available in module level' in User.objects.all().values_list('username', flat=True)
+    assert f'username_{parametrize_idx_aaa}' in User.objects.all().values_list('username', flat=True)
+    assert User.objects.count() == 3
+
+
+@pytest.mark.parametrize(
+    argnames='parametrize_idx_aaa,expected_value',
+    argvalues=((1, 1), (2, 1), (3, 1), (4, datetime(2019, 10, 11)),)
+)
+@pytest.mark.django_db
+def test_check_raise_savepiont_does_not_exist402(http_client, parametrize_idx_aaa, expected_value):
+    User.objects.create(username=f'username_{parametrize_idx_aaa}')
+
+    assert 'this user available in module level' in User.objects.all().values_list('username', flat=True)
+    assert f'username_{parametrize_idx_aaa}' in User.objects.all().values_list('username', flat=True)
+    assert User.objects.count() == 3
+
+
+@pytest.mark.django_db
+def test_check_raise_savepiont_does_not_exist5(http_client):
+    from django.db import connection
+    with CaptureQueriesContext(connection) as expected_num_queries:
+        User.objects.create(username=f'username_123')
+
+    with CaptureQueriesContext(connection) as expected_num_queries2:
+        http_client.get(path='www.naver.com')
+
+    assert len(expected_num_queries.captured_queries) == 1
+    assert User.objects.count() == 3

--- a/test_django_plugin/app/tests/test_with_bug_reproduction.py
+++ b/test_django_plugin/app/tests/test_with_bug_reproduction.py
@@ -3,7 +3,7 @@ from datetime import datetime
 import pytest
 from django.contrib.auth.models import User
 from django.test.utils import CaptureQueriesContext
-from rest_framework.test import APIClient
+
 
 
 @pytest.fixture(autouse=True)
@@ -91,8 +91,8 @@ def test_check_raise_savepiont_does_not_exist5():
     with CaptureQueriesContext(connection) as expected_num_queries:
         User.objects.create(username=f'username_123')
 
-    with CaptureQueriesContext(connection) as expected_num_queries2:
-        APIClient().get(path='www.naver.com')
+    # with CaptureQueriesContext(connection) as expected_num_queries2:
+    #     APIClient().get(path='www.naver.com')
 
     assert len(expected_num_queries.captured_queries) == 1
     assert User.objects.count() == 2

--- a/test_django_plugin/app/tests/test_with_bug_reproduction.py
+++ b/test_django_plugin/app/tests/test_with_bug_reproduction.py
@@ -3,6 +3,7 @@ from datetime import datetime
 import pytest
 from django.contrib.auth.models import User
 from django.test.utils import CaptureQueriesContext
+from rest_framework.test import APIClient
 
 
 @pytest.fixture(autouse=True)
@@ -61,14 +62,14 @@ def test_check_raise_savepiont_does_not_exist4(parametrize_idx_aaa):
     argvalues=((1, 1), (2, 1), (3, 1), (4, datetime(2019, 10, 11)),)
 )
 @pytest.mark.django_db
-def test_check_raise_savepiont_does_not_exist401(request, http_client, parametrize_idx_aaa, expected_value):
-    print(f'\n\n\n--여기여기---{request.fixturenames}----------\n\n\n')
+def test_check_raise_savepiont_does_not_exist401(request, parametrize_idx_aaa, expected_value):
+    print(f'\n\n\n--check fixtures---{request.fixturenames}----------\n\n\n')
 
     User.objects.create(username=f'username_{parametrize_idx_aaa}')
 
     assert 'this user available in module level' in User.objects.all().values_list('username', flat=True)
     assert f'username_{parametrize_idx_aaa}' in User.objects.all().values_list('username', flat=True)
-    assert User.objects.count() == 3
+    assert User.objects.count() == 2
 
 
 @pytest.mark.parametrize(
@@ -76,22 +77,22 @@ def test_check_raise_savepiont_does_not_exist401(request, http_client, parametri
     argvalues=((1, 1), (2, 1), (3, 1), (4, datetime(2019, 10, 11)),)
 )
 @pytest.mark.django_db
-def test_check_raise_savepiont_does_not_exist402(http_client, parametrize_idx_aaa, expected_value):
+def test_check_raise_savepiont_does_not_exist402(parametrize_idx_aaa, expected_value):
     User.objects.create(username=f'username_{parametrize_idx_aaa}')
 
     assert 'this user available in module level' in User.objects.all().values_list('username', flat=True)
     assert f'username_{parametrize_idx_aaa}' in User.objects.all().values_list('username', flat=True)
-    assert User.objects.count() == 3
+    assert User.objects.count() == 2
 
 
 @pytest.mark.django_db
-def test_check_raise_savepiont_does_not_exist5(http_client):
+def test_check_raise_savepiont_does_not_exist5():
     from django.db import connection
     with CaptureQueriesContext(connection) as expected_num_queries:
         User.objects.create(username=f'username_123')
 
     with CaptureQueriesContext(connection) as expected_num_queries2:
-        http_client.get(path='www.naver.com')
+        APIClient().get(path='www.naver.com')
 
     assert len(expected_num_queries.captured_queries) == 1
-    assert User.objects.count() == 3
+    assert User.objects.count() == 2

--- a/test_django_plugin/app/tests/test_with_bug_reproduction.py
+++ b/test_django_plugin/app/tests/test_with_bug_reproduction.py
@@ -48,7 +48,7 @@ def test_check_raise_savepiont_does_not_exist3():
 )
 @pytest.mark.django_db
 def test_check_raise_savepiont_does_not_exist4(parametrize_idx_aaa):
-    User.objects.create(username='username_{}'.value(parametrize_idx_aaa))
+    User.objects.create(username='username_{}'.format(parametrize_idx_aaa))
 
     # assert 'this user available in module level' in User.objects.all().values_list('username', flat=True)
     assert 'username_{}'.format(parametrize_idx_aaa) in User.objects.all().values_list('username', flat=True)

--- a/test_django_plugin/app/tests/test_with_bug_reproduction.py
+++ b/test_django_plugin/app/tests/test_with_bug_reproduction.py
@@ -64,10 +64,10 @@ def test_check_raise_savepiont_does_not_exist4(parametrize_idx_aaa):
 def test_check_raise_savepiont_does_not_exist401(request, parametrize_idx_aaa, expected_value):
     print('\n\n\n--check fixtures---{}----------\n\n\n'.format(request.fixturenames))
 
-    User.objects.create(username=f'username_{parametrize_idx_aaa}')
+    User.objects.create(username='username_{}'.format(parametrize_idx_aaa))
 
     assert 'this user available in module level' in User.objects.all().values_list('username', flat=True)
-    assert f'username_{parametrize_idx_aaa}' in User.objects.all().values_list('username', flat=True)
+    assert 'username_{}'.format(parametrize_idx_aaa) in User.objects.all().values_list('username', flat=True)
     assert User.objects.count() == 2
 
 
@@ -80,7 +80,7 @@ def test_check_raise_savepiont_does_not_exist402(parametrize_idx_aaa, expected_v
     User.objects.create(username='username_{}'.format(parametrize_idx_aaa))
 
     assert 'this user available in module level' in User.objects.all().values_list('username', flat=True)
-    assert f'username_{parametrize_idx_aaa}' in User.objects.all().values_list('username', flat=True)
+    assert 'username_{}'.format(parametrize_idx_aaa) in User.objects.all().values_list('username', flat=True)
     assert User.objects.count() == 2
 
 

--- a/test_django_plugin/app/tests/test_with_bug_reproduction2.py
+++ b/test_django_plugin/app/tests/test_with_bug_reproduction2.py
@@ -3,7 +3,7 @@ from datetime import datetime
 import pytest
 from django.contrib.auth.models import User
 from django.test.utils import CaptureQueriesContext
-from rest_framework.test import APIClient
+
 
 
 # issue: module fixture must exist,
@@ -99,8 +99,8 @@ def test_check_raise_savepiont_does_not_exist5():
     with CaptureQueriesContext(connection) as expected_num_queries:
         User.objects.create(username=f'username_123')
 
-    with CaptureQueriesContext(connection) as expected_num_queries2:
-        APIClient().get(path='www.naver.com')
+    # with CaptureQueriesContext(connection) as expected_num_queries2:
+    #     APIClient().get(path='www.naver.com')
 
     assert len(expected_num_queries.captured_queries) == 1
     assert User.objects.count() == 1

--- a/test_django_plugin/app/tests/test_with_bug_reproduction2.py
+++ b/test_django_plugin/app/tests/test_with_bug_reproduction2.py
@@ -1,0 +1,107 @@
+from datetime import datetime
+
+import pytest
+from django.contrib.auth.models import User
+from django.test.utils import CaptureQueriesContext
+
+
+# issue: module fixture must exist,
+# if not , these case raise  django.db.utils.OperationalError: (1305, 'SAVEPOINT s4737629504_x65 does not exist')
+# remove below module fixture  it should be fail
+# @pytest.fixture(scope='module', autouse=True)
+# def this_is_module_fixture(module_fixture):
+#     pass
+
+
+@pytest.fixture(scope='function', autouse=False)
+def this_is_function_fixture():
+    return User.objects.create(username='this user available in function level')
+
+
+@pytest.mark.django_db
+def test_check_raise_savepiont_does_not_exist(request, http_client):
+    #    assert User.objects.all().first().username == 'this user available in module level'
+    assert User.objects.count() == 1
+
+
+@pytest.mark.django_db
+def test_check_raise_savepiont_does_not_exist2():
+    User.objects.create(username='this user available only in this testcase')
+
+    assert 'this user available only in this testcase' in User.objects.all().values_list('username', flat=True)
+    assert User.objects.count() == 1
+
+
+@pytest.mark.usefixtures('this_is_function_fixture')
+@pytest.mark.django_db
+def test_check_raise_savepiont_does_not_exist3(http_client):
+    assert 'this user available in function level' in User.objects.all().values_list('username', flat=True)
+    assert User.objects.count() == 2
+
+
+@pytest.mark.parametrize(
+    argnames='parametrize_idx_aaa',
+    argvalues=(1, 2, 3, 4,)
+)
+@pytest.mark.django_db
+def test_check_raise_savepiont_does_not_exist4(parametrize_idx_aaa):
+    User.objects.create(username=f'username_{parametrize_idx_aaa}')
+
+    # assert 'this user available in module level' in User.objects.all().values_list('username', flat=True)
+    assert f'username_{parametrize_idx_aaa}' in User.objects.all().values_list('username', flat=True)
+    assert User.objects.count() == 1
+
+
+@pytest.mark.parametrize(
+    argnames='parametrize_idx_aaa,expected_value',
+    argvalues=((1, 1), (2, 1), (3, 1), (4, datetime(2019, 10, 11)),)
+)
+@pytest.mark.django_db
+def test_check_raise_savepiont_does_not_exist401(request, http_client, parametrize_idx_aaa, expected_value):
+    print(f'\n\n\n--여기여기---{request.fixturenames}----------\n\n\n')
+
+    User.objects.create(username=f'username_{parametrize_idx_aaa}')
+
+    assert f'username_{parametrize_idx_aaa}' in User.objects.all().values_list('username', flat=True)
+    assert User.objects.count() == 2
+
+
+@pytest.mark.parametrize(
+    argnames='parametrize_idx_aaa,expected_value',
+    argvalues=((1, 1), (2, 1), (3, 1), (4, datetime(2019, 10, 11)),)
+)
+@pytest.mark.django_db
+def test_check_raise_savepiont_does_not_exist402(http_client, parametrize_idx_aaa, expected_value):
+    User.objects.create(username=f'username_{parametrize_idx_aaa}')
+
+    assert f'username_{parametrize_idx_aaa}' in User.objects.all().values_list('username', flat=True)
+    assert User.objects.count() == 2
+
+
+
+@pytest.mark.parametrize(
+    argnames='parametrize_idx_aaa,expected_value',
+    argvalues=((1, ValueError), (2,ValueError), (3, ValueError), (4, ValueError),)
+)
+@pytest.mark.django_db
+def test_check_raise_savepiont_does_not_exist402(http_client, parametrize_idx_aaa, expected_value):
+    User.objects.create(username=f'username_{parametrize_idx_aaa}')
+    try:
+        raise ValueError
+    except ValueError:
+        pass
+    assert f'username_{parametrize_idx_aaa}' in User.objects.all().values_list('username', flat=True)
+    assert User.objects.count() == 2
+
+
+@pytest.mark.django_db
+def test_check_raise_savepiont_does_not_exist5(http_client):
+    from django.db import connection
+    with CaptureQueriesContext(connection) as expected_num_queries:
+        User.objects.create(username=f'username_123')
+
+    with CaptureQueriesContext(connection) as expected_num_queries2:
+        http_client.get(path='www.naver.com')
+
+    assert len(expected_num_queries.captured_queries) == 1
+    assert User.objects.count() == 2

--- a/test_django_plugin/app/tests/test_with_bug_reproduction2.py
+++ b/test_django_plugin/app/tests/test_with_bug_reproduction2.py
@@ -5,7 +5,6 @@ from django.contrib.auth.models import User
 from django.test.utils import CaptureQueriesContext
 
 
-
 # issue: module fixture must exist,
 # if not , these case raise  django.db.utils.OperationalError: (1305, 'SAVEPOINT s4737629504_x65 does not exist')
 # remove below module fixture  it should be fail
@@ -45,10 +44,10 @@ def test_check_raise_savepiont_does_not_exist3():
 )
 @pytest.mark.django_db
 def test_check_raise_savepiont_does_not_exist4(parametrize_idx_aaa):
-    User.objects.create(username=f'username_{parametrize_idx_aaa}')
+    User.objects.create(username='username_{}'.format(parametrize_idx_aaa))
 
     # assert 'this user available in module level' in User.objects.all().values_list('username', flat=True)
-    assert f'username_{parametrize_idx_aaa}' in User.objects.all().values_list('username', flat=True)
+    assert 'username_{}'.format(parametrize_idx_aaa) in User.objects.all().values_list('username', flat=True)
     assert User.objects.count() == 1
 
 
@@ -58,11 +57,11 @@ def test_check_raise_savepiont_does_not_exist4(parametrize_idx_aaa):
 )
 @pytest.mark.django_db
 def test_check_raise_savepiont_does_not_exist401(request, parametrize_idx_aaa, expected_value):
-    print(f'\n\n\n--check fixturenames---{request.fixturenames}----------\n\n\n')
+    print('\n\n\n--check fixturenames---{}----------\n\n\n'.format(request.fixturenames))
 
-    User.objects.create(username=f'username_{parametrize_idx_aaa}')
+    User.objects.create(username='username_{}'.format(parametrize_idx_aaa))
 
-    assert f'username_{parametrize_idx_aaa}' in User.objects.all().values_list('username', flat=True)
+    assert 'username_{}'.format(parametrize_idx_aaa) in User.objects.all().values_list('username', flat=True)
     assert User.objects.count() == 1
 
 
@@ -72,9 +71,9 @@ def test_check_raise_savepiont_does_not_exist401(request, parametrize_idx_aaa, e
 )
 @pytest.mark.django_db
 def test_check_raise_savepiont_does_not_exist402(parametrize_idx_aaa, expected_value):
-    User.objects.create(username=f'username_{parametrize_idx_aaa}')
+    User.objects.create(username='username_{}'.format(parametrize_idx_aaa))
 
-    assert f'username_{parametrize_idx_aaa}' in User.objects.all().values_list('username', flat=True)
+    assert 'username_{}'.format(parametrize_idx_aaa) in User.objects.all().values_list('username', flat=True)
     assert User.objects.count() == 1
 
 
@@ -84,12 +83,12 @@ def test_check_raise_savepiont_does_not_exist402(parametrize_idx_aaa, expected_v
 )
 @pytest.mark.django_db
 def test_check_raise_savepiont_does_not_exist402(parametrize_idx_aaa, expected_value):
-    User.objects.create(username=f'username_{parametrize_idx_aaa}')
+    User.objects.create(username='username_{}'.format(parametrize_idx_aaa))
     try:
         raise ValueError
     except ValueError:
         pass
-    assert f'username_{parametrize_idx_aaa}' in User.objects.all().values_list('username', flat=True)
+    assert 'username_{}'.format(parametrize_idx_aaa) in User.objects.all().values_list('username', flat=True)
     assert User.objects.count() == 1
 
 
@@ -97,7 +96,7 @@ def test_check_raise_savepiont_does_not_exist402(parametrize_idx_aaa, expected_v
 def test_check_raise_savepiont_does_not_exist5():
     from django.db import connection
     with CaptureQueriesContext(connection) as expected_num_queries:
-        User.objects.create(username=f'username_123')
+        User.objects.create(username='username_123')
 
     # with CaptureQueriesContext(connection) as expected_num_queries2:
     #     APIClient().get(path='www.naver.com')

--- a/test_django_plugin/app/tests/test_with_bug_reproduction2.py
+++ b/test_django_plugin/app/tests/test_with_bug_reproduction2.py
@@ -3,6 +3,7 @@ from datetime import datetime
 import pytest
 from django.contrib.auth.models import User
 from django.test.utils import CaptureQueriesContext
+from rest_framework.test import APIClient
 
 
 # issue: module fixture must exist,
@@ -19,9 +20,8 @@ def this_is_function_fixture():
 
 
 @pytest.mark.django_db
-def test_check_raise_savepiont_does_not_exist(request, http_client):
-    #    assert User.objects.all().first().username == 'this user available in module level'
-    assert User.objects.count() == 1
+def test_check_raise_savepiont_does_not_exist(request):
+    assert User.objects.count() == 0
 
 
 @pytest.mark.django_db
@@ -34,9 +34,9 @@ def test_check_raise_savepiont_does_not_exist2():
 
 @pytest.mark.usefixtures('this_is_function_fixture')
 @pytest.mark.django_db
-def test_check_raise_savepiont_does_not_exist3(http_client):
+def test_check_raise_savepiont_does_not_exist3():
     assert 'this user available in function level' in User.objects.all().values_list('username', flat=True)
-    assert User.objects.count() == 2
+    assert User.objects.count() == 1
 
 
 @pytest.mark.parametrize(
@@ -57,13 +57,13 @@ def test_check_raise_savepiont_does_not_exist4(parametrize_idx_aaa):
     argvalues=((1, 1), (2, 1), (3, 1), (4, datetime(2019, 10, 11)),)
 )
 @pytest.mark.django_db
-def test_check_raise_savepiont_does_not_exist401(request, http_client, parametrize_idx_aaa, expected_value):
-    print(f'\n\n\n--여기여기---{request.fixturenames}----------\n\n\n')
+def test_check_raise_savepiont_does_not_exist401(request, parametrize_idx_aaa, expected_value):
+    print(f'\n\n\n--check fixturenames---{request.fixturenames}----------\n\n\n')
 
     User.objects.create(username=f'username_{parametrize_idx_aaa}')
 
     assert f'username_{parametrize_idx_aaa}' in User.objects.all().values_list('username', flat=True)
-    assert User.objects.count() == 2
+    assert User.objects.count() == 1
 
 
 @pytest.mark.parametrize(
@@ -71,37 +71,36 @@ def test_check_raise_savepiont_does_not_exist401(request, http_client, parametri
     argvalues=((1, 1), (2, 1), (3, 1), (4, datetime(2019, 10, 11)),)
 )
 @pytest.mark.django_db
-def test_check_raise_savepiont_does_not_exist402(http_client, parametrize_idx_aaa, expected_value):
+def test_check_raise_savepiont_does_not_exist402(parametrize_idx_aaa, expected_value):
     User.objects.create(username=f'username_{parametrize_idx_aaa}')
 
     assert f'username_{parametrize_idx_aaa}' in User.objects.all().values_list('username', flat=True)
-    assert User.objects.count() == 2
-
+    assert User.objects.count() == 1
 
 
 @pytest.mark.parametrize(
     argnames='parametrize_idx_aaa,expected_value',
-    argvalues=((1, ValueError), (2,ValueError), (3, ValueError), (4, ValueError),)
+    argvalues=((1, ValueError), (2, ValueError), (3, ValueError), (4, ValueError),)
 )
 @pytest.mark.django_db
-def test_check_raise_savepiont_does_not_exist402(http_client, parametrize_idx_aaa, expected_value):
+def test_check_raise_savepiont_does_not_exist402(parametrize_idx_aaa, expected_value):
     User.objects.create(username=f'username_{parametrize_idx_aaa}')
     try:
         raise ValueError
     except ValueError:
         pass
     assert f'username_{parametrize_idx_aaa}' in User.objects.all().values_list('username', flat=True)
-    assert User.objects.count() == 2
+    assert User.objects.count() == 1
 
 
 @pytest.mark.django_db
-def test_check_raise_savepiont_does_not_exist5(http_client):
+def test_check_raise_savepiont_does_not_exist5():
     from django.db import connection
     with CaptureQueriesContext(connection) as expected_num_queries:
         User.objects.create(username=f'username_123')
 
     with CaptureQueriesContext(connection) as expected_num_queries2:
-        http_client.get(path='www.naver.com')
+        APIClient().get(path='www.naver.com')
 
     assert len(expected_num_queries.captured_queries) == 1
-    assert User.objects.count() == 2
+    assert User.objects.count() == 1


### PR DESCRIPTION
this issue  occurs execution with multiple modules test

each single module test succeeds

#### `pytest tests/test_with_bug_reproduction`  (success)
#### `pytest tests/test_with_bug_reproduction2` (success)

#### but
in the case of multiple modules tests  fail
#### `pytest tests` (fail)

---

see this fail log 
commit `remove APIClient()`
https://travis-ci.org/tipsi/pytest-tipsi-django/jobs/603388438?utm_medium=notification&utm_source=github_status

~~~Python
>           transaction.savepoint_rollback(sid)
pytest_tipsi_django/django_fixtures.py:90: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
.tox/py37/lib/python3.7/site-packages/django/db/transaction.py:57: in savepoint_rollback
    get_connection(using).savepoint_rollback(sid)
.tox/py37/lib/python3.7/site-packages/django/db/backends/base/base.py:344: in savepoint_rollback
    self._savepoint_rollback(sid)

...
...
E  django.db.transaction.TransactionManagementError: An error occurred in the current transaction. You can't execute queries until the end of the 'atomic' block.

~~~

---


And this is my local env case  fail log , **when i use MYSQL**    
raise these log
~~~Python
E       django.db.utils.OperationalError: (1305, 'SAVEPOINT s4737629504_x65 does not exist')

../../../../../venv/lib/python3.7/site-packages/MySQLdb/connections.py:224: OperationalError
~~~

---
### it can be resolved just one line modification (auto =True)
~~~Python
@pytest.fixture(scope='module',  autouse=True)
def module_fixture(request, module_transaction):
~~~

if you Approve this PR  
I remove test_with_bug_reproduction1,2.py
And Merge Only these one line
~~~Python
@pytest.fixture(scope='module',  autouse=True)
def module_fixture(request, module_transaction):
~~~